### PR TITLE
adding new cos url and updating timemouts also adding the force_recovery attribute

### DIFF
--- a/image.tf
+++ b/image.tf
@@ -8,7 +8,7 @@ resource "ibm_is_image" "vnf_custom_image" {
 
 
   timeouts {
-    create = "30m"
-    delete = "10m"
+    create = "60m"
+    delete = "20m"
   }
 }

--- a/instance.tf
+++ b/instance.tf
@@ -35,6 +35,7 @@ resource "ibm_is_instance" "fgt1" {
   image   = ibm_is_image.vnf_custom_image.id
   profile = var.PROFILE
 
+
   primary_network_interface {
     name                 = "${var.CLUSTER_NAME}-port1-${random_string.random_suffix.result}"
     subnet               = data.ibm_is_subnet.subnet1.id
@@ -73,7 +74,15 @@ resource "ibm_is_instance" "fgt1" {
   zone      = var.ZONE
   user_data = data.template_file.userdata_active.rendered
   keys      = [data.ibm_is_ssh_key.ssh_key.id]
-
+// Timeout issues persist. See https://www.ibm.com/cloud/blog/timeout-errors-with-ibm-cloud-schematics
+  timeouts {
+    create = "60m"
+    update = "60m"
+    delete = "60m"
+  }
+  // Force IBM to recover from perpetual 'starting state' see:
+  // https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_instance#force_recovery_time
+  force_recovery_time = 20
 }
 
 // Secondary FortiGate
@@ -116,6 +125,15 @@ resource "ibm_is_instance" "fgt2" {
   zone      = var.ZONE
   user_data = data.template_file.userdata_passive.rendered
   keys      = [data.ibm_is_ssh_key.ssh_key.id]
+  //Timeout issues persist. See https://www.ibm.com/cloud/blog/timeout-errors-with-ibm-cloud-schematics
+  timeouts {
+    create = "60m"
+    update = "60m"
+    delete = "60m"
+  }
+  // Force IBM to recover from perpetual 'starting state' see:
+  // https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_instance#force_recovery_time
+  force_recovery_time = 20
 }
 
 // Use for bootstrapping cloud-init

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.27.0"
+      version = "~> 1.29.0"
     }
   }
 }

--- a/vars.tf
+++ b/vars.tf
@@ -140,7 +140,7 @@ resource "random_string" "random_suffix" {
 // 6.4.4 available link: cos://us-geo/fortinet/fortigate_byol_644_b1803_GA.qcow2
 // cos://us-geo/fortinet/fortigate_byol_700_b0066_GA.qcow2 7.0
 variable "image" {
-  default = "cos://us-geo/fortinet/fortigate_byol_700_b0066_GA.qcow2"
+  default = "cos://us-geo/fortinet/fortigate_byol_701_b0157_GA.qcow2"
 }
 variable "IBMCLOUD_API_KEY" {
   default     = ""


### PR DESCRIPTION
I figure add this all into one since we will need to test these changes anyways.

- Adds the new 7.0.1 cos URL
- adds timeouts for instance to 60m
- increases image timeouts to 60m
- adds force_recovery_time = 20;
See  https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/is_instance#force_recovery_time

Will need to test this change, but it should improve the issues with timeouts. 