### PR TITLE
Updating ibm provider to 1.42.0

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.40.1"
+      version = "~> 1.42.0"
     }
   }
 }


### PR DESCRIPTION
This update should fix the issue with floating IPs
Reference for IBM's fix: https://github.com/IBM-Cloud/terraform-provider-ibm/releases/tag/v1.41.1
