### PR TITLE
Add attempts ci

### DIFF
--- a/ci/pipeline/fortigate-tf-pipeline.yml
+++ b/ci/pipeline/fortigate-tf-pipeline.yml
@@ -4,7 +4,7 @@ resources:
     icon: github
     source:
       uri: https://github.com/fortinet/ibm-fortigate-AP-HA-terraform-deploy.git
-      branch: add_attempts_ci
+      branch: main
   - name: terraform-image
     type: registry-image
     icon: terraform


### PR DESCRIPTION
This commit will try to solve the repeated IBM failures while automatic deployment testing. Ideally, we should be fixing the IP assignment to not go ahead, it will be revisited in the future. This change will add [attempts](https://concourse-ci.org/attempts-step.html) which will retry this task step 3 times before declaring a failure. 