### PR TITLE
Adds security group to the passive vni

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ After the active VM is back up, it will take over as active once again.
 -   Two FortiOS 7.0 BYOL Licenses.
 -   [A VPC with four subnets in a single zone](https://cloud.ibm.com/docs/vpc/vpc-getting-started-with-ibm-cloud-virtual-private-cloud-infrastructure)
 -   [A configured IBM SSH key](https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys)
--   [A security group](https://cloud.ibm.com/docs/security-groups?topic=security-groups-about-ibm-security-groups)
+-   [A public gateway](https://cloud.ibm.com/docs/vpc?topic=vpc-about-public-gateways) attached to the public subnet (its ID is a required input)
 
 ## Deployment overview
 
@@ -21,6 +21,23 @@ Terraform deploys the following components:
 -   Three floating Public IP addresses: one attached to the Primary FortiGate on Port1, which will failover and the other two attached to the HA management port (Port4) of each FortiGate.
 -   One log disk per FortiGate.
 -   A basic bootstrap configuration with HA support.
+-   Two security groups, created and attached automatically (see [Security groups](#security-groups) below).
+
+### Security groups
+
+The template creates and attaches two security groups — no pre-existing security group is required.
+
+| Security group | Attached to | Direction | Protocol / Port | Remote | Purpose |
+| -------------- | ----------------------------------------- | -------- | --------------- | ------------------- | ------------------------------------------ |
+| **Public** | Port1 (external), Port4 (HA management) | Inbound | TCP 443 | `0.0.0.0/0` | HTTPS admin GUI access *(see Note below)* |
+| | | Inbound | All | Same security group | Traffic between cluster members |
+| | | Outbound | UDP 53 | `0.0.0.0/0` | FortiGuard DNS & SDNS queries |
+| | | Outbound | TCP 443 | `0.0.0.0/0` | Licensing, FortiCare & IBM SDN connector |
+| | | Outbound | TCP 8890 | `0.0.0.0/0` | FortiGuard distribution updates |
+| **Private** | Port2 (internal), Port3 (HA heartbeat) | Inbound | All | Same security group | HA heartbeat/sync between cluster members |
+| | | Outbound | All | Same security group | HA heartbeat/sync between cluster members |
+
+> **Note:** The inbound HTTPS rule is open to `0.0.0.0/0` to allow initial access to the admin GUI. After initial configuration, it is recommended to lock the rule's remote down to a trusted host or CIDR.
 
 # Deployment Diagram
 
@@ -30,7 +47,7 @@ Terraform deploys the following components:
 
 > **Note:** For Subnets, the UUID is required.
 
-1. Fill in the required Subnets, security group and VPC information as shown in the example below:
+1. Fill in the required Subnets, public gateway and VPC information as shown in the example below:
 
 
    ![IBM FortiGate Example Inputs](imgs/IBM_ha_example.png)
@@ -38,7 +55,7 @@ Terraform deploys the following components:
   
 
 3. Apply the plan.
-4. Outputs, such as the **Public IP** and **Default username and password** can be found under the `View Log` link.
+4. Outputs, such as the **Public IP**, **Default username and password** and the names of the created **Security Groups** can be found under the `View Log` link.
 
 ## Destroy the cluster
 

--- a/output.tf
+++ b/output.tf
@@ -21,3 +21,12 @@ output "FGT1_Default_Admin_Password" {
 output "FGT2_Default_Admin_Password" {
   value = ibm_is_instance.fgt2.id
 }
+output "Security_Group_Port1_Name" {
+  description = "The name of the security group attached to FortiGate port1"
+  value       = local.security_group_port1_name
+}
+
+output "Security_Group_Port2_Name" {
+  description = "The name of the security group attached to FortiGate port2"
+  value       = local.security_group_port2_name
+}

--- a/output.tf
+++ b/output.tf
@@ -21,12 +21,12 @@ output "FGT1_Default_Admin_Password" {
 output "FGT2_Default_Admin_Password" {
   value = ibm_is_instance.fgt2.id
 }
-output "Security_Group_Port1_Name" {
+output "Security_Group_Public_Name" {
   description = "The name of the security group attached to FortiGate port1"
-  value       = local.security_group_port1_name
+  value       = local.security_group_public_name
 }
 
-output "Security_Group_Port2_Name" {
+output "Security_Group_Private_Name" {
   description = "The name of the security group attached to FortiGate port2"
-  value       = local.security_group_port2_name
+  value       = local.security_group_private_name
 }

--- a/output.tf
+++ b/output.tf
@@ -22,11 +22,11 @@ output "FGT2_Default_Admin_Password" {
   value = ibm_is_instance.fgt2.id
 }
 output "Security_Group_Public_Name" {
-  description = "The name of the security group attached to FortiGate port1"
+  description = "The name of the security group attached to FortiGate port1 and port4"
   value       = local.security_group_public_name
 }
 
 output "Security_Group_Private_Name" {
-  description = "The name of the security group attached to FortiGate port2"
+  description = "The name of the security group attached to FortiGate port2 and port3"
   value       = local.security_group_private_name
 }

--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "~> 1.68.0"
+      version = "~> 2.4.0"
     }
   }
 }

--- a/vars.tf
+++ b/vars.tf
@@ -130,14 +130,14 @@ variable "FGT2_PORT4_MGMT_GATEWAY" {
   default     = ""
   description = "Gateway for Port 4 (HA management port) on the secondary (PASSIVE) FortiGate."
 }
-variable "SECURITY_GROUP_PUBLIC" {
-  type        = string
-  description = "Required. The name of an existing Security Group to attach to the FortiGate instance Network Interface for Port 1 and Port 4."
-}
-variable "SECURITY_GROUP_PRIVATE" {
-  type        = string
-  description = "Required. The name of an existing Security Group to attach to the FortiGate instance Network Interface for Port 2 and Port 3."
-}
+# variable "SECURITY_GROUP_PUBLIC" {
+#   type        = string
+#   description = "Required. The name of an existing Security Group to attach to the FortiGate instance Network Interface for Port 1 and Port 4."
+# }
+# variable "SECURITY_GROUP_PRIVATE" {
+#   type        = string
+#   description = "Required. The name of an existing Security Group to attach to the FortiGate instance Network Interface for Port 2 and Port 3."
+# }
 
 variable "RESOURCE_GRP" {
   type        = string
@@ -146,8 +146,8 @@ variable "RESOURCE_GRP" {
 }
 
 variable "PUBLIC_GATEWAY_ID" {
- type = string
- description = "The Public Gateway ID for the Public Subnet"
+  type        = string
+  description = "The Public Gateway ID for the Public Subnet"
 }
 
 data "ibm_resource_group" "rg" {

--- a/vars.tf
+++ b/vars.tf
@@ -132,13 +132,11 @@ variable "FGT2_PORT4_MGMT_GATEWAY" {
 }
 variable "SECURITY_GROUP_PUBLIC" {
   type        = string
-  default     = ""
-  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 1 and Port 4."
+  description = "Required. The name of an existing Security Group to attach to the FortiGate instance Network Interface for Port 1 and Port 4."
 }
 variable "SECURITY_GROUP_PRIVATE" {
   type        = string
-  default     = ""
-  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 2 and Port 3."
+  description = "Required. The name of an existing Security Group to attach to the FortiGate instance Network Interface for Port 2 and Port 3."
 }
 
 variable "RESOURCE_GRP" {

--- a/vars.tf
+++ b/vars.tf
@@ -130,15 +130,15 @@ variable "FGT2_PORT4_MGMT_GATEWAY" {
   default     = ""
   description = "Gateway for Port 4 (HA management port) on the secondary (PASSIVE) FortiGate."
 }
-variable "SECURITY_GROUP_PORT1" {
+variable "SECURITY_GROUP_PUBLIC" {
   type        = string
   default     = ""
-  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 1."
+  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 1 and Port 4."
 }
-variable "SECURITY_GROUP_PORT2" {
+variable "SECURITY_GROUP_PRIVATE" {
   type        = string
   default     = ""
-  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 2."
+  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 2 and Port 3."
 }
 
 variable "RESOURCE_GRP" {

--- a/vars.tf
+++ b/vars.tf
@@ -130,10 +130,15 @@ variable "FGT2_PORT4_MGMT_GATEWAY" {
   default     = ""
   description = "Gateway for Port 4 (HA management port) on the secondary (PASSIVE) FortiGate."
 }
-variable "SECURITY_GROUP" {
+variable "SECURITY_GROUP_PORT1" {
   type        = string
   default     = ""
-  description = "The Security Group to attach to the FortiGate instance Network Interfaces."
+  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 1."
+}
+variable "SECURITY_GROUP_PORT2" {
+  type        = string
+  default     = ""
+  description = "The Security Group to attach to the FortiGate instance Network Interface for Port 2."
 }
 
 variable "RESOURCE_GRP" {

--- a/vars.tf
+++ b/vars.tf
@@ -145,6 +145,11 @@ variable "RESOURCE_GRP" {
   description = "The RESOURCE Group Name to attach to the FortiGate instances."
 }
 
+variable "PUBLIC_GATEWAY_ID" {
+ type = string
+ description = "The Public Gateway ID for the Public Subnet"
+}
+
 data "ibm_resource_group" "rg" {
   name = var.RESOURCE_GRP
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -16,98 +16,18 @@ data "ibm_is_subnet" "subnet4" {
 }
 
 data "ibm_is_security_group" "fgt_security_group_public" {
-  count = var.SECURITY_GROUP_PUBLIC != "" ? 1 : 0
-  name  = var.SECURITY_GROUP_PUBLIC
+  name = var.SECURITY_GROUP_PUBLIC
 }
 
 data "ibm_is_security_group" "fgt_security_group_private" {
-  count = var.SECURITY_GROUP_PRIVATE != "" ? 1 : 0
-  name  = var.SECURITY_GROUP_PRIVATE
-}
-
-resource "ibm_is_security_group" "fgt_security_group_public" {
-  count = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
-  name  = "${var.CLUSTER_NAME}-fgt-sg-public-${random_string.random_suffix.result}"
-  vpc   = data.ibm_is_vpc.vpc1.id
-}
-
-resource "ibm_is_security_group" "fgt_security_group_private" {
-  count = var.SECURITY_GROUP_PRIVATE == "" ? 1 : 0
-  name  = "${var.CLUSTER_NAME}-fgt-sg-private-${random_string.random_suffix.result}"
-  vpc   = data.ibm_is_vpc.vpc1.id
+  name = var.SECURITY_GROUP_PRIVATE
 }
 
 locals {
-  security_group_public_id    = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].id : ibm_is_security_group.fgt_security_group_public[0].id
-  security_group_private_id   = var.SECURITY_GROUP_PRIVATE != "" ? data.ibm_is_security_group.fgt_security_group_private[0].id : ibm_is_security_group.fgt_security_group_private[0].id
-  security_group_public_name  = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].name : ibm_is_security_group.fgt_security_group_public[0].name
-  security_group_private_name = var.SECURITY_GROUP_PRIVATE != "" ? data.ibm_is_security_group.fgt_security_group_private[0].name : ibm_is_security_group.fgt_security_group_private[0].name
-
-}
-
-#Rules to enable HA talk, only added to the private SG created by this template
-resource "ibm_is_security_group_rule" "ingress_traffic" {
-  count = var.SECURITY_GROUP_PRIVATE == "" ? 1 : 0
-  group = ibm_is_security_group.fgt_security_group_private[0].id
-
-  direction = "inbound"
-  remote    = ibm_is_security_group.fgt_security_group_private[0].id
-}
-
-resource "ibm_is_security_group_rule" "egress_traffic" {
-  count = var.SECURITY_GROUP_PRIVATE == "" ? 1 : 0
-  group = ibm_is_security_group.fgt_security_group_private[0].id
-
-  direction = "outbound"
-  remote    = ibm_is_security_group.fgt_security_group_private[0].id
-}
-
-#Rules for the public SG created by this template (port1 public + port4 HA mgmt)
-resource "ibm_is_security_group_rule" "public_ingress_https" {
-  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
-  group     = ibm_is_security_group.fgt_security_group_public[0].id
-  direction = "inbound"
-  remote    = "0.0.0.0/0"
-  protocol  = "tcp"
-  port_min  = 443
-  port_max  = 443
-}
-
-resource "ibm_is_security_group_rule" "public_ingress_ssh" {
-  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
-  group     = ibm_is_security_group.fgt_security_group_public[0].id
-  direction = "inbound"
-  remote    = "0.0.0.0/0"
-  protocol  = "tcp"
-  port_min  = 22
-  port_max  = 22
-}
-
-resource "ibm_is_security_group_rule" "public_ingress_fgfm" {
-  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
-  group     = ibm_is_security_group.fgt_security_group_public[0].id
-  direction = "inbound"
-  remote    = "0.0.0.0/0"
-  protocol  = "tcp"
-  port_min  = 541
-  port_max  = 541
-}
-
-resource "ibm_is_security_group_rule" "public_ingress_ping" {
-  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
-  group     = ibm_is_security_group.fgt_security_group_public[0].id
-  direction = "inbound"
-  remote    = "0.0.0.0/0"
-  protocol  = "icmp"
-  type      = 8
-}
-
-#Outbound open for FortiGuard, licensing, the IBM SDN connector API calls and egress traffic through port1
-resource "ibm_is_security_group_rule" "public_egress_all" {
-  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
-  group     = ibm_is_security_group.fgt_security_group_public[0].id
-  direction = "outbound"
-  remote    = "0.0.0.0/0"
+  security_group_public_id    = data.ibm_is_security_group.fgt_security_group_public.id
+  security_group_private_id   = data.ibm_is_security_group.fgt_security_group_private.id
+  security_group_public_name  = data.ibm_is_security_group.fgt_security_group_public.name
+  security_group_private_name = data.ibm_is_security_group.fgt_security_group_private.name
 }
 
 locals {

--- a/vpc.tf
+++ b/vpc.tf
@@ -45,12 +45,18 @@ locals {
 
 }
 
-#Rule to enable HA talk
-resource "ibm_is_security_group_rule" "internal_traffic" {
+#Rules to enable HA talk
+resource "ibm_is_security_group_rule" "ingress_traffic" {
   group = local.security_group_private_id
 
   direction = "inbound"
-  local     = "0.0.0.0/0"
+  remote    = local.security_group_private_id
+}
+
+resource "ibm_is_security_group_rule" "egress_traffic" {
+  group = local.security_group_private_id
+
+  direction = "outbound"
   remote    = local.security_group_private_id
 }
 

--- a/vpc.tf
+++ b/vpc.tf
@@ -14,8 +14,35 @@ data "ibm_is_subnet" "subnet3" {
 data "ibm_is_subnet" "subnet4" {
   identifier = var.SUBNET_4
 }
-data "ibm_is_security_group" "fgt_security_group" {
-  name = var.SECURITY_GROUP
+
+data "ibm_is_security_group" "fgt_security_group_port1" {
+  count = var.SECURITY_GROUP_PORT1 != "" ? 1 : 0
+  name = var.SECURITY_GROUP_PORT1
+}
+
+data "ibm_is_security_group" "fgt_security_group_port2" {
+  count = var.SECURITY_GROUP_PORT2 != "" ? 1 : 0
+  name = var.SECURITY_GROUP_PORT2
+}
+
+resource "ibm_is_security_group" "fgt_security_group_port1" {
+  count = var.SECURITY_GROUP_PORT1 == "" ? 1 : 0
+  name  = "${var.CLUSTER_NAME}-fgt-sg-port1-${random_string.random_suffix.result}"
+  vpc   = data.ibm_is_vpc.vpc1.id
+}
+
+resource "ibm_is_security_group" "fgt_security_group_port2" {
+  count = var.SECURITY_GROUP_PORT2 == "" ? 1 : 0
+  name  = "${var.CLUSTER_NAME}-fgt-sg-port2-${random_string.random_suffix.result}"
+  vpc   = data.ibm_is_vpc.vpc1.id
+}
+
+locals {
+  security_group_port1_id = var.SECURITY_GROUP_PORT1 != "" ? data.ibm_is_security_group.fgt_security_group_port1[0].id : ibm_is_security_group.fgt_security_group_port1[0].id
+  security_group_port2_id = var.SECURITY_GROUP_PORT2 != "" ? data.ibm_is_security_group.fgt_security_group_port2[0].id : ibm_is_security_group.fgt_security_group_port2[0].id
+  security_group_port1_name = var.SECURITY_GROUP_PORT1 != "" ? data.ibm_is_security_group.fgt_security_group_port1[0].name : ibm_is_security_group.fgt_security_group_port1[0].name
+  security_group_port2_name = var.SECURITY_GROUP_PORT2 != "" ? data.ibm_is_security_group.fgt_security_group_port2[0].name : ibm_is_security_group.fgt_security_group_port2[0].name
+
 }
 
 locals {
@@ -64,7 +91,7 @@ resource "ibm_is_virtual_network_interface" "vni-active" {
   allow_ip_spoofing         = false
   auto_delete               = false
   enable_infrastructure_nat = true
-  security_groups           = [data.ibm_is_security_group.fgt_security_group.id]
+  security_groups           = [local.security_group_port1_id]
   resource_group            = data.ibm_resource_group.rg.id
 
   primary_ip {
@@ -80,7 +107,7 @@ resource "ibm_is_virtual_network_interface" "vni-passive" {
   allow_ip_spoofing         = false
   auto_delete               = false
   enable_infrastructure_nat = true
-  security_groups           = [data.ibm_is_security_group.fgt_security_group.id]
+  security_groups           = [local.security_group_port2_id]
   resource_group            = data.ibm_resource_group.rg.id
 
   primary_ip {

--- a/vpc.tf
+++ b/vpc.tf
@@ -45,19 +45,69 @@ locals {
 
 }
 
-#Rules to enable HA talk
+#Rules to enable HA talk, only added to the private SG created by this template
 resource "ibm_is_security_group_rule" "ingress_traffic" {
-  group = local.security_group_private_id
+  count = var.SECURITY_GROUP_PRIVATE == "" ? 1 : 0
+  group = ibm_is_security_group.fgt_security_group_private[0].id
 
   direction = "inbound"
-  remote    = local.security_group_private_id
+  remote    = ibm_is_security_group.fgt_security_group_private[0].id
 }
 
 resource "ibm_is_security_group_rule" "egress_traffic" {
-  group = local.security_group_private_id
+  count = var.SECURITY_GROUP_PRIVATE == "" ? 1 : 0
+  group = ibm_is_security_group.fgt_security_group_private[0].id
 
   direction = "outbound"
-  remote    = local.security_group_private_id
+  remote    = ibm_is_security_group.fgt_security_group_private[0].id
+}
+
+#Rules for the public SG created by this template (port1 public + port4 HA mgmt)
+resource "ibm_is_security_group_rule" "public_ingress_https" {
+  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
+  group     = ibm_is_security_group.fgt_security_group_public[0].id
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "tcp"
+  port_min  = 443
+  port_max  = 443
+}
+
+resource "ibm_is_security_group_rule" "public_ingress_ssh" {
+  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
+  group     = ibm_is_security_group.fgt_security_group_public[0].id
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "tcp"
+  port_min  = 22
+  port_max  = 22
+}
+
+resource "ibm_is_security_group_rule" "public_ingress_fgfm" {
+  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
+  group     = ibm_is_security_group.fgt_security_group_public[0].id
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "tcp"
+  port_min  = 541
+  port_max  = 541
+}
+
+resource "ibm_is_security_group_rule" "public_ingress_ping" {
+  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
+  group     = ibm_is_security_group.fgt_security_group_public[0].id
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "icmp"
+  type      = 8
+}
+
+#Outbound open for FortiGuard, licensing, the IBM SDN connector API calls and egress traffic through port1
+resource "ibm_is_security_group_rule" "public_egress_all" {
+  count     = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
+  group     = ibm_is_security_group.fgt_security_group_public[0].id
+  direction = "outbound"
+  remote    = "0.0.0.0/0"
 }
 
 locals {

--- a/vpc.tf
+++ b/vpc.tf
@@ -15,19 +15,103 @@ data "ibm_is_subnet" "subnet4" {
   identifier = var.SUBNET_4
 }
 
-data "ibm_is_security_group" "fgt_security_group_public" {
-  name = var.SECURITY_GROUP_PUBLIC
+# ============================================================================
+# Security Group - Public (port1 external + port4 HA management)
+# Inbound : self-referencing (inter-FGT only)
+# Outbound: restricted to FortiGuard services required for licensing/DNS/updates
+# ============================================================================
+
+resource "ibm_is_security_group" "fgt_sg_public" {
+  name           = "${var.CLUSTER_NAME}-sg-public-${random_string.random_suffix.result}"
+  vpc            = data.ibm_is_vpc.vpc1.id
+  resource_group = data.ibm_resource_group.rg.id
 }
 
-data "ibm_is_security_group" "fgt_security_group_private" {
-  name = var.SECURITY_GROUP_PRIVATE
+# Inbound - allow traffic only from interfaces in this same SG (inter-FGT)
+resource "ibm_is_security_group_rule" "fgt_public_inbound_self" {
+  group     = ibm_is_security_group.fgt_sg_public.id
+  direction = "inbound"
+  remote    = ibm_is_security_group.fgt_sg_public.id
+  name      = "allow-inbound-from-same-sg"
+}
+
+# Inbound - TCP 443 for HTTPS admin GUI access
+resource "ibm_is_security_group_rule" "fgt_public_inbound_https" {
+  group     = ibm_is_security_group.fgt_sg_public.id
+  direction = "inbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "tcp"
+  port_min  = 443
+  port_max  = 443
+  name      = "allow-inbound-https-tcp-443"
+}
+
+# Outbound - UDP 53 for FortiGuard DNS & SDNS queries
+resource "ibm_is_security_group_rule" "fgt_public_outbound_dns" {
+  group     = ibm_is_security_group.fgt_sg_public.id
+  direction = "outbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "udp"
+  port_min  = 53
+  port_max  = 53
+  name      = "allow-outbound-fortiguard-dns-udp-53"
+}
+
+# Outbound - TCP 443 for Licensing, FortiCare & Entitlements
+resource "ibm_is_security_group_rule" "fgt_public_outbound_https" {
+  group     = ibm_is_security_group.fgt_sg_public.id
+  direction = "outbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "tcp"
+  port_min  = 443
+  port_max  = 443
+  name      = "allow-outbound-fortiguard-licensing-tcp-443"
+}
+
+# Outbound - TCP 8890 for FortiGuard Distribution Updates (optional)
+resource "ibm_is_security_group_rule" "fgt_public_outbound_fortiguard_updates" {
+  group     = ibm_is_security_group.fgt_sg_public.id
+  direction = "outbound"
+  remote    = "0.0.0.0/0"
+  protocol  = "tcp"
+  port_min  = 8890
+  port_max  = 8890
+  name      = "allow-outbound-fortiguard-updates-tcp-8890"
+}
+
+# ============================================================================
+# Security Group - Private (port2 internal + port3 HA heartbeat)
+# Inbound : self-referencing (inter-FGT only)
+# Outbound: self-referencing only — no internet access needed on private ports
+# ============================================================================
+
+resource "ibm_is_security_group" "fgt_sg_private" {
+  name           = "${var.CLUSTER_NAME}-sg-private-${random_string.random_suffix.result}"
+  vpc            = data.ibm_is_vpc.vpc1.id
+  resource_group = data.ibm_resource_group.rg.id
+}
+
+# Inbound - allow traffic only from interfaces in this same SG (inter-FGT)
+resource "ibm_is_security_group_rule" "fgt_private_inbound_self" {
+  group     = ibm_is_security_group.fgt_sg_private.id
+  direction = "inbound"
+  remote    = ibm_is_security_group.fgt_sg_private.id
+  name      = "allow-inbound-from-same-sg"
+}
+
+# Outbound - allow traffic only to interfaces in this same SG (inter-FGT)
+resource "ibm_is_security_group_rule" "fgt_private_outbound_self" {
+  group     = ibm_is_security_group.fgt_sg_private.id
+  direction = "outbound"
+  remote    = ibm_is_security_group.fgt_sg_private.id
+  name      = "allow-outbound-to-same-sg"
 }
 
 locals {
-  security_group_public_id    = data.ibm_is_security_group.fgt_security_group_public.id
-  security_group_private_id   = data.ibm_is_security_group.fgt_security_group_private.id
-  security_group_public_name  = data.ibm_is_security_group.fgt_security_group_public.name
-  security_group_private_name = data.ibm_is_security_group.fgt_security_group_private.name
+  security_group_public_id    = ibm_is_security_group.fgt_sg_public.id
+  security_group_private_id   = ibm_is_security_group.fgt_sg_private.id
+  security_group_public_name  = ibm_is_security_group.fgt_sg_public.name
+  security_group_private_name = ibm_is_security_group.fgt_sg_private.name
 }
 
 locals {

--- a/vpc.tf
+++ b/vpc.tf
@@ -80,6 +80,7 @@ resource "ibm_is_virtual_network_interface" "vni-passive" {
   allow_ip_spoofing         = false
   auto_delete               = false
   enable_infrastructure_nat = true
+  security_groups           = [data.ibm_is_security_group.fgt_security_group.id]
   resource_group            = data.ibm_resource_group.rg.id
 
   primary_ip {

--- a/vpc.tf
+++ b/vpc.tf
@@ -15,33 +15,33 @@ data "ibm_is_subnet" "subnet4" {
   identifier = var.SUBNET_4
 }
 
-data "ibm_is_security_group" "fgt_security_group_port1" {
-  count = var.SECURITY_GROUP_PORT1 != "" ? 1 : 0
-  name = var.SECURITY_GROUP_PORT1
+data "ibm_is_security_group" "fgt_security_group_public" {
+  count = var.SECURITY_GROUP_PUBLIC != "" ? 1 : 0
+  name = var.SECURITY_GROUP_PUBLIC
 }
 
-data "ibm_is_security_group" "fgt_security_group_port2" {
-  count = var.SECURITY_GROUP_PORT2 != "" ? 1 : 0
-  name = var.SECURITY_GROUP_PORT2
+data "ibm_is_security_group" "fgt_security_group_private" {
+  count = var.SECURITY_GROUP_PRIVATE != "" ? 1 : 0
+  name = var.SECURITY_GROUP_PRIVATE
 }
 
-resource "ibm_is_security_group" "fgt_security_group_port1" {
-  count = var.SECURITY_GROUP_PORT1 == "" ? 1 : 0
-  name  = "${var.CLUSTER_NAME}-fgt-sg-port1-${random_string.random_suffix.result}"
+resource "ibm_is_security_group" "fgt_security_group_public" {
+  count = var.SECURITY_GROUP_PUBLIC == "" ? 1 : 0
+  name  = "${var.CLUSTER_NAME}-fgt-sg-public-${random_string.random_suffix.result}"
   vpc   = data.ibm_is_vpc.vpc1.id
 }
 
-resource "ibm_is_security_group" "fgt_security_group_port2" {
-  count = var.SECURITY_GROUP_PORT2 == "" ? 1 : 0
-  name  = "${var.CLUSTER_NAME}-fgt-sg-port2-${random_string.random_suffix.result}"
+resource "ibm_is_security_group" "fgt_security_group_private" {
+  count = var.SECURITY_GROUP_PRIVATE == "" ? 1 : 0
+  name  = "${var.CLUSTER_NAME}-fgt-sg-private-${random_string.random_suffix.result}"
   vpc   = data.ibm_is_vpc.vpc1.id
 }
 
 locals {
-  security_group_port1_id = var.SECURITY_GROUP_PORT1 != "" ? data.ibm_is_security_group.fgt_security_group_port1[0].id : ibm_is_security_group.fgt_security_group_port1[0].id
-  security_group_port2_id = var.SECURITY_GROUP_PORT2 != "" ? data.ibm_is_security_group.fgt_security_group_port2[0].id : ibm_is_security_group.fgt_security_group_port2[0].id
-  security_group_port1_name = var.SECURITY_GROUP_PORT1 != "" ? data.ibm_is_security_group.fgt_security_group_port1[0].name : ibm_is_security_group.fgt_security_group_port1[0].name
-  security_group_port2_name = var.SECURITY_GROUP_PORT2 != "" ? data.ibm_is_security_group.fgt_security_group_port2[0].name : ibm_is_security_group.fgt_security_group_port2[0].name
+  security_group_public_id = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].id : ibm_is_security_group.fgt_security_group_public[0].id
+  security_group_private_id = var.SECURITY_GROUP_PRIVATE != "" ? data.ibm_is_security_group.fgt_security_group_private[0].id : ibm_is_security_group.fgt_security_group_private[0].id
+  security_group_public_name = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].name : ibm_is_security_group.fgt_security_group_public[0].name
+  security_group_private_name = var.SECURITY_GROUP_PRIVATE != "" ? data.ibm_is_security_group.fgt_security_group_private[0].name : ibm_is_security_group.fgt_security_group_private[0].name
 
 }
 
@@ -50,36 +50,44 @@ locals {
     "interface1" = {
       ip     = var.FGT1_STATIC_IP_PORT1,
       subnet = var.SUBNET_1
+      security_group = local.security_group_public_id
     },
     "interface2" = {
       ip     = var.FGT1_STATIC_IP_PORT2,
       subnet = var.SUBNET_2
+      security_group = local.security_group_private_id
     },
     "interface3" = {
       ip     = var.FGT1_STATIC_IP_PORT3,
       subnet = var.SUBNET_3
+      security_group = local.security_group_private_id
     },
     "interface4" = {
       ip     = var.FGT1_STATIC_IP_PORT4,
       subnet = var.SUBNET_4
+      security_group = local.security_group_public_id
     },
   }
   passive = {
     "interface1" = {
       ip     = var.FGT2_STATIC_IP_PORT1,
       subnet = var.SUBNET_1
+      security_group = local.security_group_public_id
     },
     "interface2" = {
       ip     = var.FGT2_STATIC_IP_PORT2,
       subnet = var.SUBNET_2
+      security_group = local.security_group_private_id
     },
     "interface3" = {
       ip     = var.FGT2_STATIC_IP_PORT3,
       subnet = var.SUBNET_3
+      security_group = local.security_group_private_id
     },
     "interface4" = {
       ip     = var.FGT2_STATIC_IP_PORT4,
       subnet = var.SUBNET_4
+      security_group = local.security_group_public_id
     },
   }
 
@@ -91,7 +99,7 @@ resource "ibm_is_virtual_network_interface" "vni-active" {
   allow_ip_spoofing         = false
   auto_delete               = false
   enable_infrastructure_nat = true
-  security_groups           = [local.security_group_port1_id]
+  security_groups           = [each.value.security_group]
   resource_group            = data.ibm_resource_group.rg.id
 
   primary_ip {
@@ -107,7 +115,7 @@ resource "ibm_is_virtual_network_interface" "vni-passive" {
   allow_ip_spoofing         = false
   auto_delete               = false
   enable_infrastructure_nat = true
-  security_groups           = [local.security_group_port2_id]
+  security_groups           = [each.value.security_group]
   resource_group            = data.ibm_resource_group.rg.id
 
   primary_ip {

--- a/vpc.tf
+++ b/vpc.tf
@@ -17,12 +17,12 @@ data "ibm_is_subnet" "subnet4" {
 
 data "ibm_is_security_group" "fgt_security_group_public" {
   count = var.SECURITY_GROUP_PUBLIC != "" ? 1 : 0
-  name = var.SECURITY_GROUP_PUBLIC
+  name  = var.SECURITY_GROUP_PUBLIC
 }
 
 data "ibm_is_security_group" "fgt_security_group_private" {
   count = var.SECURITY_GROUP_PRIVATE != "" ? 1 : 0
-  name = var.SECURITY_GROUP_PRIVATE
+  name  = var.SECURITY_GROUP_PRIVATE
 }
 
 resource "ibm_is_security_group" "fgt_security_group_public" {
@@ -38,55 +38,64 @@ resource "ibm_is_security_group" "fgt_security_group_private" {
 }
 
 locals {
-  security_group_public_id = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].id : ibm_is_security_group.fgt_security_group_public[0].id
-  security_group_private_id = var.SECURITY_GROUP_PRIVATE != "" ? data.ibm_is_security_group.fgt_security_group_private[0].id : ibm_is_security_group.fgt_security_group_private[0].id
-  security_group_public_name = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].name : ibm_is_security_group.fgt_security_group_public[0].name
+  security_group_public_id    = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].id : ibm_is_security_group.fgt_security_group_public[0].id
+  security_group_private_id   = var.SECURITY_GROUP_PRIVATE != "" ? data.ibm_is_security_group.fgt_security_group_private[0].id : ibm_is_security_group.fgt_security_group_private[0].id
+  security_group_public_name  = var.SECURITY_GROUP_PUBLIC != "" ? data.ibm_is_security_group.fgt_security_group_public[0].name : ibm_is_security_group.fgt_security_group_public[0].name
   security_group_private_name = var.SECURITY_GROUP_PRIVATE != "" ? data.ibm_is_security_group.fgt_security_group_private[0].name : ibm_is_security_group.fgt_security_group_private[0].name
 
+}
+
+#Rule to enable HA talk
+resource "ibm_is_security_group_rule" "internal_traffic" {
+  group = local.security_group_private_id
+
+  direction = "inbound"
+  local     = "0.0.0.0/0"
+  remote    = local.security_group_private_id
 }
 
 locals {
   active = {
     "interface1" = {
-      ip     = var.FGT1_STATIC_IP_PORT1,
-      subnet = var.SUBNET_1
+      ip             = var.FGT1_STATIC_IP_PORT1,
+      subnet         = var.SUBNET_1
       security_group = local.security_group_public_id
     },
     "interface2" = {
-      ip     = var.FGT1_STATIC_IP_PORT2,
-      subnet = var.SUBNET_2
+      ip             = var.FGT1_STATIC_IP_PORT2,
+      subnet         = var.SUBNET_2
       security_group = local.security_group_private_id
     },
     "interface3" = {
-      ip     = var.FGT1_STATIC_IP_PORT3,
-      subnet = var.SUBNET_3
+      ip             = var.FGT1_STATIC_IP_PORT3,
+      subnet         = var.SUBNET_3
       security_group = local.security_group_private_id
     },
     "interface4" = {
-      ip     = var.FGT1_STATIC_IP_PORT4,
-      subnet = var.SUBNET_4
+      ip             = var.FGT1_STATIC_IP_PORT4,
+      subnet         = var.SUBNET_4
       security_group = local.security_group_public_id
     },
   }
   passive = {
     "interface1" = {
-      ip     = var.FGT2_STATIC_IP_PORT1,
-      subnet = var.SUBNET_1
+      ip             = var.FGT2_STATIC_IP_PORT1,
+      subnet         = var.SUBNET_1
       security_group = local.security_group_public_id
     },
     "interface2" = {
-      ip     = var.FGT2_STATIC_IP_PORT2,
-      subnet = var.SUBNET_2
+      ip             = var.FGT2_STATIC_IP_PORT2,
+      subnet         = var.SUBNET_2
       security_group = local.security_group_private_id
     },
     "interface3" = {
-      ip     = var.FGT2_STATIC_IP_PORT3,
-      subnet = var.SUBNET_3
+      ip             = var.FGT2_STATIC_IP_PORT3,
+      subnet         = var.SUBNET_3
       security_group = local.security_group_private_id
     },
     "interface4" = {
-      ip     = var.FGT2_STATIC_IP_PORT4,
-      subnet = var.SUBNET_4
+      ip             = var.FGT2_STATIC_IP_PORT4,
+      subnet         = var.SUBNET_4
       security_group = local.security_group_public_id
     },
   }


### PR DESCRIPTION
- Defines segregated security groups for port1 and port2
- SG variables are now optional for and if not provided, SGs will be auto created.
- Output updated to reflect name of the SGs.
- Changes already tested with a dummy VPC and security group.

Closes mantis https://mantis.fortinet.com/bug_view_page.php?bug_id=1309832